### PR TITLE
Prevent browser save prompts for invoice addresses

### DIFF
--- a/faktorio-fe/src/pages/ReceivedInvoicesPage.tsx
+++ b/faktorio-fe/src/pages/ReceivedInvoicesPage.tsx
@@ -554,7 +554,7 @@ export function ReceivedInvoicesPage() {
                         <FormItem>
                           <FormLabel>Ulice</FormLabel>
                           <FormControl>
-                            <Input {...field} />
+                            <Input autoComplete="off" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -568,7 +568,7 @@ export function ReceivedInvoicesPage() {
                           <FormItem>
                             <FormLabel>Město</FormLabel>
                             <FormControl>
-                              <Input {...field} />
+                              <Input autoComplete="off" {...field} />
                             </FormControl>
                             <FormMessage />
                           </FormItem>
@@ -581,7 +581,7 @@ export function ReceivedInvoicesPage() {
                           <FormItem>
                             <FormLabel>PSČ</FormLabel>
                             <FormControl>
-                              <Input {...field} />
+                              <Input autoComplete="off" {...field} />
                             </FormControl>
                             <FormMessage />
                           </FormItem>
@@ -595,7 +595,7 @@ export function ReceivedInvoicesPage() {
                         <FormItem>
                           <FormLabel>Země</FormLabel>
                           <FormControl>
-                            <Input {...field} />
+                            <Input autoComplete="off" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>


### PR DESCRIPTION
Added autoComplete="off" to all supplier address input fields (street, city, zip, country) in the received invoices form to prevent browsers from prompting to save addresses.