### PR TITLE
Calculate VAT from summed tax base and support per-rate breakdown fields

### DIFF
--- a/faktorio-fe/src/components/IssuedInvoiceTable.tsx
+++ b/faktorio-fe/src/components/IssuedInvoiceTable.tsx
@@ -53,7 +53,13 @@ export type Invoice = Pick<
   | 'paid_on'
   | 'client_vat_no'
   | 'exchange_rate'
->
+> &
+  Partial<
+    Pick<
+      InferSelectModel<typeof invoicesTb>,
+      'vat_base_21' | 'vat_21' | 'vat_base_12' | 'vat_12'
+    >
+  >
 
 // Helper type for currency totals
 type CurrencyTotals = {

--- a/faktorio-fe/src/components/ReceivedInvoiceTable.tsx
+++ b/faktorio-fe/src/components/ReceivedInvoiceTable.tsx
@@ -28,7 +28,13 @@ export type ReceivedInvoice = Pick<
   | 'total_with_vat'
   | 'currency'
   | 'status'
->
+> &
+  Partial<
+    Pick<
+      InferSelectModel<typeof receivedInvoiceTb>,
+      'vat_base_21' | 'vat_21' | 'vat_base_12' | 'vat_12'
+    >
+  >
 
 interface ReceivedInvoiceTableProps {
   invoices: ReceivedInvoice[]

--- a/faktorio-fe/src/lib/generateDanovePriznaniXML.test.ts
+++ b/faktorio-fe/src/lib/generateDanovePriznaniXML.test.ts
@@ -170,6 +170,140 @@ describe('generateDanovePriznaniXML', () => {
     )
   })
 
+  it('calculates row 1 VAT directly from the summed base to match ADIS validation', () => {
+    const submitterData: SubmitterData = {
+      dic: 'CZ12345678',
+      naz_obce: 'Brno',
+      typ_ds: 'F',
+      jmeno: 'Test',
+      prijmeni: 'Submitter',
+      ulice: 'Test Street 1',
+      psc: '12345',
+      stat: 'ČESKÁ REPUBLIKA',
+      email: 'test@example.com'
+    }
+
+    const issuedInvoices: Invoice[] = [
+      {
+        id: '1',
+        number: 'INV001',
+        client_name: 'Client A',
+        client_vat_no: 'CZ87654321',
+        due_on: new Date('2024-07-20').toISOString(),
+        issued_on: new Date('2024-07-10').toISOString(),
+        sent_at: null,
+        paid_on: null,
+        exchange_rate: 1,
+        taxable_fulfillment_due: new Date('2024-07-15').toISOString(),
+        subtotal: 100000,
+        native_subtotal: 100000,
+        native_total: 120940,
+        total: 120940,
+        currency: 'CZK'
+      },
+      {
+        id: '2',
+        number: 'INV002',
+        client_name: 'Client B',
+        client_vat_no: 'CZ11223344',
+        due_on: new Date('2024-07-25').toISOString(),
+        issued_on: new Date('2024-07-15').toISOString(),
+        sent_at: null,
+        paid_on: null,
+        exchange_rate: 1,
+        taxable_fulfillment_due: new Date('2024-07-15').toISOString(),
+        subtotal: 256756,
+        native_subtotal: 256756,
+        native_total: 310515,
+        total: 310515,
+        currency: 'CZK'
+      }
+    ]
+
+    const xmlString = generateDanovePriznaniXML({
+      issuedInvoices,
+      receivedInvoices: [],
+      submitterData,
+      year: 2024,
+      quarter: 3,
+      czkSumEurServices: 0
+    })
+
+    expect(xmlString).toMatch(/<Veta1[\s\S]*obrat23="356756" dan23="74919"/)
+  })
+
+  it('uses 21% VAT breakdown fields when invoices contain multiple VAT rates', () => {
+    const submitterData: SubmitterData = {
+      dic: 'CZ12345678',
+      naz_obce: 'Brno',
+      typ_ds: 'F',
+      jmeno: 'Test',
+      prijmeni: 'Submitter',
+      ulice: 'Test Street 1',
+      psc: '12345',
+      stat: 'ČESKÁ REPUBLIKA',
+      email: 'test@example.com'
+    }
+
+    const issuedInvoices: Invoice[] = [
+      {
+        id: '1',
+        number: 'INV001',
+        client_name: 'Client A',
+        client_vat_no: 'CZ87654321',
+        due_on: new Date('2024-07-20').toISOString(),
+        issued_on: new Date('2024-07-10').toISOString(),
+        sent_at: null,
+        paid_on: null,
+        exchange_rate: 1,
+        taxable_fulfillment_due: new Date('2024-07-15').toISOString(),
+        subtotal: 1120,
+        native_subtotal: 1120,
+        native_total: 1316,
+        vat_base_21: 800,
+        vat_21: 168,
+        vat_base_12: 320,
+        vat_12: 38.4,
+        total: 1316,
+        currency: 'CZK'
+      }
+    ]
+
+    const receivedInvoices: ReceivedInvoice[] = [
+      {
+        id: 'rec1',
+        invoice_number: 'REC001',
+        supplier_name: 'Supplier X',
+        supplier_vat_no: 'CZ99887766',
+        issue_date: new Date('2024-07-20').toISOString(),
+        taxable_supply_date: new Date('2024-07-20').toISOString(),
+        due_date: '2024-08-05',
+        status: 'received',
+        total_without_vat: 560,
+        total_with_vat: 658,
+        vat_base_21: 400,
+        vat_21: 84,
+        vat_base_12: 160,
+        vat_12: 19.2,
+        currency: 'CZK'
+      }
+    ]
+
+    const xmlString = generateDanovePriznaniXML({
+      issuedInvoices,
+      receivedInvoices,
+      submitterData,
+      year: 2024,
+      quarter: 3,
+      czkSumEurServices: 0
+    })
+
+    expect(xmlString).toMatch(/<Veta1[\s\S]*obrat23="800" dan23="168"/)
+    expect(xmlString).toMatch(
+      /<Veta4[\s\S]*pln23="400" odp_tuz23_nar="84"[\s\S]*odp_sum_nar="84"/
+    )
+  })
+
   // Restore real timers after tests
   afterAll(() => {
     vi.useRealTimers()

--- a/faktorio-fe/src/lib/generateDanovePriznaniXML.ts
+++ b/faktorio-fe/src/lib/generateDanovePriznaniXML.ts
@@ -13,6 +13,27 @@ interface GenerateDanovePriznaniParams {
   month?: number
 }
 
+const VAT_RATE_21 = 0.21
+
+/**
+ * ADIS validates VAT amount against the tax base (rounded to whole CZK in XML).
+ * To avoid cumulative floating point drift (or mixed per-invoice rounding),
+ * we calculate VAT from the summed base in haléře and then convert back to CZK.
+ */
+function calculateVatFromBase(base: number, rate: number): number {
+  const baseInHalers = Math.round(base * 100)
+  const vatInHalers = Math.round(baseInHalers * rate)
+  return vatInHalers / 100
+}
+
+function hasIssuedVatBreakdown(invoice: Invoice): boolean {
+  return invoice.vat_base_21 !== null && invoice.vat_base_21 !== undefined
+}
+
+function hasReceivedVatBreakdown(invoice: ReceivedInvoice): boolean {
+  return invoice.vat_base_21 !== null && invoice.vat_base_21 !== undefined
+}
+
 export function generateDanovePriznaniXML({
   issuedInvoices,
   receivedInvoices,
@@ -25,25 +46,28 @@ export function generateDanovePriznaniXML({
   const todayCzech = formatCzechDate(new Date())
 
   // Calculate sums for <Veta1>
-  let obrat23 = 0
-  let dan23 = 0
-  issuedInvoices.forEach((inv) => {
-    const subtotal = inv.native_subtotal ?? 0
-    const vatAmount = (inv.native_total ?? 0) - subtotal
-    obrat23 += subtotal
-    dan23 += vatAmount
-  })
+  const hasIssuedBreakdown = issuedInvoices.some(hasIssuedVatBreakdown)
+  const obrat23 = issuedInvoices.reduce((sum, inv) => {
+    if (hasIssuedBreakdown) {
+      return sum + (inv.vat_base_21 ?? 0)
+    }
+
+    return sum + (inv.native_subtotal ?? 0)
+  }, 0)
+
+  const dan23 = calculateVatFromBase(obrat23, VAT_RATE_21)
 
   // Calculate sums for <Veta4>
-  let pln23 = 0
-  let odp_tuz23_nar = 0
-  receivedInvoices.forEach((inv) => {
-    const subtotal = inv.total_without_vat ?? 0
-    const totalWithVat = inv.total_with_vat ?? 0
-    const vatAmount = totalWithVat - subtotal
-    pln23 += subtotal
-    odp_tuz23_nar += vatAmount
-  })
+  const hasReceivedBreakdown = receivedInvoices.some(hasReceivedVatBreakdown)
+  const pln23 = receivedInvoices.reduce((sum, inv) => {
+    if (hasReceivedBreakdown) {
+      return sum + (inv.vat_base_21 ?? 0)
+    }
+
+    return sum + (inv.total_without_vat ?? 0)
+  }, 0)
+
+  const odp_tuz23_nar = calculateVatFromBase(pln23, VAT_RATE_21)
   const odp_sum_nar = odp_tuz23_nar // In this simplified case, they are the same
 
   // Calculate sums for <Veta6>


### PR DESCRIPTION
### Motivation

- Ensure ADIS XML validation passes by deriving VAT from the summed tax base instead of summing per-invoice VAT to avoid rounding drift.
- Support invoices and received invoices that include explicit VAT breakdown fields (e.g. `vat_base_21`, `vat_21`) so the XML generation can use those when available.

### Description

- Extended `Invoice` and `ReceivedInvoice` types in `IssuedInvoiceTable.tsx` and `ReceivedInvoiceTable.tsx` to include optional VAT breakdown fields via a `Partial` `Pick` of `vat_base_21`, `vat_21`, `vat_base_12`, and `vat_12`.
- Reworked `generateDanovePriznaniXML` to: use a `VAT_RATE_21` constant, detect when invoices contain VAT breakdowns, sum the appropriate base fields when present, and compute VAT from the summed base using `calculateVatFromBase` to avoid cumulative rounding errors.
- Added helpers `calculateVatFromBase`, `hasIssuedVatBreakdown`, and `hasReceivedVatBreakdown` to centralize the calculation and detection logic.
- Kept period selection behavior and final XML assembly intact while ensuring `dan23`, `odp_tuz23_nar`, and related totals are derived from the summed bases.
- Added unit tests in `generateDanovePriznaniXML.test.ts` covering VAT-from-summed-base behavior and usage of 21% VAT breakdown fields.

### Testing

- Ran the unit test suite with `vitest`, and the `generateDanovePriznaniXML` tests including the newly added cases completed successfully.
- The new tests verify that VAT is calculated from the summed base (`row 1` scenario) and that 21% breakdown fields are used when present, and both assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e97d64f08332b82a5118012afce6)