### PR TITLE
Add invoice duplication flow (list/detail → new invoice prefill)

### DIFF
--- a/faktorio-fe/src/components/IssuedInvoiceTable.tsx
+++ b/faktorio-fe/src/components/IssuedInvoiceTable.tsx
@@ -18,6 +18,7 @@ import { RemoveDialogUncontrolled } from '@/components/RemoveDialog'
 import {
   LucideEllipsisVertical,
   Pencil,
+  Copy,
   Trash2,
   CheckCircle,
   XCircle,
@@ -159,6 +160,15 @@ export function IssuedInvoiceTable({
           <Link href={`/invoices/${invoice.id}`} className="flex w-full">
             <Eye size={16} strokeWidth="1.5" />
             <span className="ml-2">Zobrazit PDF</span>
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Link
+            href={`/new-invoice?duplicateFrom=${invoice.id}`}
+            className="flex w-full"
+          >
+            <Copy size={16} strokeWidth="1.5" />
+            <span className="ml-2">Duplikovat</span>
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={(e) => e.preventDefault()}>

--- a/faktorio-fe/src/pages/InvoiceDetail/InvoiceDetailPage.tsx
+++ b/faktorio-fe/src/pages/InvoiceDetail/InvoiceDetailPage.tsx
@@ -25,6 +25,7 @@ import {
 } from 'faktorio-api/src/zodDbSchemas'
 import {
   LucideEdit,
+  Copy,
   Copy as CopyIcon,
   Trash2,
   Eye,
@@ -244,6 +245,15 @@ export const InvoiceDetail = ({
                 >
                   <LucideEdit />
                   Upravit
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => {
+                    navigate(`/new-invoice?duplicateFrom=${invoice.id}`)
+                  }}
+                >
+                  <Copy />
+                  Duplikovat
                 </Button>
               </div>
             </div>

--- a/faktorio-fe/src/pages/invoice/NewInvoicePage.tsx
+++ b/faktorio-fe/src/pages/invoice/NewInvoicePage.tsx
@@ -19,7 +19,7 @@ import {
 } from 'faktorio-api/src/zodDbSchemas'
 import { useCallback, useEffect, useState } from 'react'
 import { Center } from '../../components/Center'
-import { useLocation } from 'wouter'
+import { useLocation, useSearchParams } from 'wouter'
 import {
   Form,
   FormControl,
@@ -113,7 +113,14 @@ const LocalizedNumberInput = ({
 }
 
 export const NewInvoicePage = () => {
+  const [searchParams] = useSearchParams()
+  const duplicateFromInvoiceId = searchParams.get('duplicateFrom')
   const [lastInvoice] = trpcClient.invoices.lastInvoiceThisYear.useSuspenseQuery()
+  const invoiceToDuplicateQuery = trpcClient.invoices.getById.useQuery(
+    { id: duplicateFromInvoiceId ?? '' },
+    { enabled: !!duplicateFromInvoiceId }
+  )
+  const invoiceToDuplicate = invoiceToDuplicateQuery.data
   const [contacts] = trpcClient.contacts.all.useSuspenseQuery()
   const [invoicingDetails] = trpcClient.invoicingDetails.useSuspenseQuery()
   const primaryBankAccount = getPrimaryBankAccount(invoicingDetails)
@@ -155,6 +162,51 @@ export const NewInvoicePage = () => {
       ]
     }
   })
+
+  useEffect(() => {
+    if (!invoiceToDuplicate) {
+      return
+    }
+
+    const shiftDateToCurrentMonth = (dateString: string) => {
+      const sourceDate = djs(dateString)
+      if (!sourceDate.isValid()) {
+        return djs().format('YYYY-MM-DD')
+      }
+
+      const now = djs()
+      const daysInCurrentMonth = now.daysInMonth()
+      const dayOfMonth = Math.min(sourceDate.date(), daysInCurrentMonth)
+
+      return now.date(dayOfMonth).format('YYYY-MM-DD')
+    }
+
+    form.reset({
+      ...form.getValues(),
+      number: nextInvoiceNumber,
+      currency: invoiceToDuplicate.currency,
+      issued_on: shiftDateToCurrentMonth(invoiceToDuplicate.issued_on),
+      taxable_fulfillment_due: shiftDateToCurrentMonth(
+        invoiceToDuplicate.taxable_fulfillment_due
+      ),
+      payment_method: invoiceToDuplicate.payment_method,
+      footer_note: invoiceToDuplicate.footer_note ?? '',
+      due_in_days: invoiceToDuplicate.due_in_days,
+      client_contact_id: invoiceToDuplicate.client_contact_id,
+      exchange_rate: invoiceToDuplicate.exchange_rate,
+      bank_account: invoiceToDuplicate.bank_account ?? '',
+      iban: invoiceToDuplicate.iban ?? '',
+      swift_bic: invoiceToDuplicate.swift_bic ?? '',
+      language: invoiceToDuplicate.language,
+      items: invoiceToDuplicate.items.map((item) => ({
+        description: item.description,
+        unit: item.unit,
+        quantity: item.quantity,
+        unit_price: item.unit_price,
+        vat_rate: item.vat_rate
+      }))
+    })
+  }, [form, invoiceToDuplicate, nextInvoiceNumber])
 
   const [selectedBankAccountId, setSelectedBankAccountId] = useState<string>(
     () => {


### PR DESCRIPTION
### Motivation
- Provide a quick way to duplicate an existing invoice from the invoice list or detail view and open a pre-filled new invoice form.
- Ensure duplicated invoices use the next invoice number and shift date fields into the current month to avoid stale dates.

### Description
- Added a "Duplikovat" menu item to `IssuedInvoiceTable` that links to `/new-invoice?duplicateFrom=<id>` and imported the `Copy` icon.
- Added a "Duplikovat" button to `InvoiceDetailPage` that navigates to the same duplicate URL and imported the `Copy` icon.
- In `NewInvoicePage`, read the `duplicateFrom` query parameter with `useSearchParams`, fetch the source invoice via `trpcClient.invoices.getById` (enabled only when the id is present), and reset the form when the invoice is available to pre-fill fields and items while keeping `number` set to the computed next invoice number.
- Implemented date-shifting logic using `djs` so `issued_on` and `taxable_fulfillment_due` are moved to the current month while keeping a valid day-of-month, and mapped invoice items into the new form schema.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) which passed, and no new automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17fdda3f4883328ad8a5f693d5066c)