### PR TITLE
Fix invoice client updates

### DIFF
--- a/faktorio-api/src/routers/invoices/invoiceRouter.ts
+++ b/faktorio-api/src/routers/invoices/invoiceRouter.ts
@@ -11,7 +11,6 @@ import {
   SQL,
   and,
   count,
-  asc,
   desc,
   eq,
   gte,
@@ -479,6 +478,17 @@ export const invoiceRouter = trpcContext.router({
         throw new Error('Invoice not found')
       }
 
+      const client = await ctx.db.query.contactTb.findFirst({
+        where: and(
+          eq(contactTb.id, input.invoice.client_contact_id),
+          eq(contactTb.user_id, ctx.user.id)
+        )
+      })
+
+      if (!client) {
+        throw new Error('Client not found')
+      }
+
       await ctx.db.transaction(async (tx) => {
         const invoiceSums = getInvoiceSums(
           input.items,
@@ -500,7 +510,15 @@ export const invoiceRouter = trpcContext.router({
             ...input.invoice,
             due_on,
             ...invoiceSums,
-            exchange_rate: input.invoice.exchange_rate ?? 1
+            exchange_rate: input.invoice.exchange_rate ?? 1,
+            client_name: client.name,
+            client_street: client.street ?? '',
+            client_street2: client.street2,
+            client_city: client.city ?? '',
+            client_zip: client.zip,
+            client_country: client.country,
+            client_registration_no: client.registration_no,
+            client_vat_no: client.vat_no
           })
           .where(eq(invoicesTb.id, input.id))
           .execute()

--- a/faktorio-fe/src/pages/invoice/EditInvoicePage.tsx
+++ b/faktorio-fe/src/pages/invoice/EditInvoicePage.tsx
@@ -145,8 +145,9 @@ export const EditInvoicePage = () => {
 
   const [_location, navigate] = useLocation()
   const updateInvoice = trpcClient.invoices.update.useMutation()
+  const selectedContactId = form.watch('client_contact_id')
   const contact = contactsQuery.data?.find(
-    (contact) => contact.id === invoice.client_contact_id
+    (contact) => contact.id === selectedContactId
   )
 
   const formValues = form.watch()
@@ -307,7 +308,7 @@ export const EditInvoicePage = () => {
         .add(formValues.due_in_days, 'day')
         .format('YYYY-MM-DD'),
       your_name: invoice.your_name ?? '',
-      client_contact_id: invoice.client_contact_id
+      client_contact_id: formValues.client_contact_id
     }
     setPreviewInvoice(invoiceCompleteForPreview)
   }, [formValues, invoiceItems])
@@ -344,10 +345,7 @@ export const EditInvoicePage = () => {
 
             await updateInvoice.mutateAsync({
               id: invoice.id,
-              invoice: {
-                ...formattedInvoice,
-                client_contact_id: contact.id
-              },
+              invoice: formattedInvoice,
               items: values.items
             })
 


### PR DESCRIPTION
### Motivation
- The invoice edit flow used the invoice's original `client_contact_id` when saving which caused changes to the selected odběratel not to persist in the stored invoice/PDF.
- The stored invoice snapshot fields (client name/address/VAT) were not refreshed on update so the detail view still showed the old client data.
- The update route did not validate that the selected client belongs to the current user before persisting the snapshot fields.

### Description
- In `faktorio-fe/src/pages/invoice/EditInvoicePage.tsx` the contact lookup now uses the form value via `form.watch('client_contact_id')`, the preview uses `formValues.client_contact_id`, and the save sends the formatted invoice payload (`invoice: formattedInvoice`) from the form.
- In `faktorio-api/src/routers/invoices/invoiceRouter.ts` the update mutation now validates the `client_contact_id` belongs to the current user and persists client snapshot fields (`client_name`, `client_street`, `client_street2`, `client_city`, `client_zip`, `client_country`, `client_registration_no`, `client_vat_no`) during the invoice update so PDFs/details reflect the new odběratel.
- Removed an unused `asc` import from the touched invoice router to silence a lint warning.

### Testing
- Ran type checks with `pnpm --filter faktorio-api tsc && pnpm --filter faktorio-fe tsc` and they completed successfully.
- Ran linter with `pnpm lint` which finished with warnings but no errors.
- Re-ran `pnpm --filter faktorio-api tsc` as an extra type-check which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27faf9ba488332bb64cd6598bbd3bb)