### PR TITLE
Add ISDOC download option and improve shared invoice download UI

### DIFF
--- a/faktorio-fe/src/pages/SharedInvoicePage.tsx
+++ b/faktorio-fe/src/pages/SharedInvoicePage.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams } from 'wouter'
 import { PDFDownloadLink, PDFViewer } from '@react-pdf/renderer'
 import { CzechInvoicePDF } from './InvoiceDetail/CzechInvoicePDF'
 import { EnglishInvoicePDF } from './InvoiceDetail/EnglishInvoicePDF'
+import { Download } from 'lucide-react'
+import { snakeCase } from 'lodash-es'
 import { Button } from '@/components/ui/button'
+import { generateIsdocXml } from '@/lib/isdoc/generateIsdocXml'
 import { trpcClient } from '@/lib/trpcClient'
 
 const PUBLIC_API_BASE = (import.meta as any).env.VITE_PUBLIC_API_URL as
@@ -47,7 +50,9 @@ export function SharedInvoicePage() {
   const invoice = data.invoice
   const items = data.items
 
-  const pdfName = `${invoice.your_name}-${invoice.number}.pdf`
+  const baseFileName = `${snakeCase(invoice.your_name ?? '')}-${invoice.number}`
+  const pdfName = `${baseFileName}.pdf`
+  const isdocName = `${baseFileName}.isdoc`
 
   const docProps = {
     invoiceData: { ...invoice, items },
@@ -59,6 +64,28 @@ export function SharedInvoicePage() {
   const onDownload = () => {
     if (!shareId) return
     sharedInvoiceEvent.mutate({ shareId, type: 'download' })
+  }
+
+  const handleIsdocDownload = () => {
+    try {
+      const xml = generateIsdocXml(
+        { ...invoice, items },
+        data.vatPayer ?? false
+      )
+
+      const blob = new Blob([xml], { type: 'application/xml' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = isdocName
+      document.body.appendChild(a)
+      a.click()
+      URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+      onDownload()
+    } catch (error) {
+      console.error('Error downloading ISDOC:', error)
+    }
   }
 
   return (
@@ -86,14 +113,31 @@ export function SharedInvoicePage() {
         </PDFViewer>
       </div>
 
-      <div className="flex justify-center">
-        <PDFDownloadLink
-          document={<PdfComponent {...docProps} />}
-          onClick={onDownload}
-          fileName={pdfName}
-        >
-          <Button>Stáhnout {pdfName}</Button>
-        </PDFDownloadLink>
+      <div className="rounded-lg border bg-background p-5 shadow-sm">
+        <h4 className="text-lg font-semibold text-foreground">
+          Stažení faktury
+        </h4>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Stáhněte si fakturu ve formátu PDF nebo ISDOC.
+        </p>
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+          <PDFDownloadLink
+            document={<PdfComponent {...docProps} />}
+            onClick={onDownload}
+            fileName={pdfName}
+          >
+            <Button className="w-full sm:w-32">
+              <Download className="mr-2 h-4 w-4" /> PDF
+            </Button>
+          </PDFDownloadLink>
+          <Button
+            className="w-full sm:w-32"
+            variant="outline"
+            onClick={handleIsdocDownload}
+          >
+            <Download className="mr-2 h-4 w-4" /> ISDOC
+          </Button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
### Motivation
- Provide users a way to download shared invoices in ISDOC format in addition to PDF and improve the download UI and filename generation.

### Description
- Use `snakeCase` to build a sanitized `baseFileName` and introduce `isdocName` alongside the existing PDF filename.
- Import and use `generateIsdocXml` and add `handleIsdocDownload` which generates an ISDOC XML blob, triggers a browser download, and calls the existing `onDownload` event hook.
- Replace the single PDF download button with a small download card that exposes both a `PDF` download via `PDFDownloadLink` and an `ISDOC` download button, and add the `Download` icon to buttons.
- Remove the unused `useMemo` import at the top of the file.

### Testing
- Performed TypeScript typecheck and local frontend build which completed successfully.
- No automated unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311f5f79a883329c100123c4bd34d9)