### PR TITLE
Normalize Czech domestic bank accounts to IBAN in SPD QR payloads

### DIFF
--- a/faktorio-fe/src/lib/qrCodeGenerator.spec.ts
+++ b/faktorio-fe/src/lib/qrCodeGenerator.spec.ts
@@ -37,14 +37,14 @@ describe('generateQrPaymentString', () => {
 
   it('converts Czech domestic account numbers to IBAN for SPD QR payments', () => {
     const qrPaymentData = generateQrPaymentString({
-      accountNumber: '670100-2214376555/6210',
+      accountNumber: '670100-9999999999/1111',
       amount: 100,
       currency: 'CZK',
       variableSymbol: '20260001'
     })
 
     expect(qrPaymentData).toBe(
-      'SPD*1.0*ACC:CZ4362106701002214376555*AM:100.00*CC:CZK*X-VS:20260001'
+      'SPD*1.0*ACC:CZ7511116701009999999999*AM:100.00*CC:CZK*X-VS:20260001'
     )
   })
 })

--- a/faktorio-fe/src/lib/qrCodeGenerator.spec.ts
+++ b/faktorio-fe/src/lib/qrCodeGenerator.spec.ts
@@ -1,8 +1,11 @@
-import { generateQrPaymentString } from './qrCodeGenerator'
-import { BankingInfo } from './qrCodeGenerator'
+import {
+  BankingInfo,
+  generateQrPaymentString,
+  normalizeAccountNumberForQrPayment
+} from './qrCodeGenerator'
 import { describe, expect, it } from 'vitest'
 
-describe('description', () => {
+describe('generateQrPaymentString', () => {
   it('should generate', () => {
     // Example usage:
     const bankingInfo: BankingInfo = {
@@ -27,6 +30,35 @@ describe('description', () => {
     }
 
     const qrPaymentData2 = generateQrPaymentString(bankingInfo2)
-    expect(qrPaymentData2).toMatchInlineSnapshot(`"SPD*1.0*ACC:CZ6220100000002200152294*AM:10.00*CC:CZK*X-VS:112233"`)
+    expect(qrPaymentData2).toMatchInlineSnapshot(
+      `"SPD*1.0*ACC:CZ6220100000002200152294*AM:10.00*CC:CZK*X-VS:112233"`
+    )
+  })
+
+  it('converts Czech domestic account numbers to IBAN for SPD QR payments', () => {
+    const qrPaymentData = generateQrPaymentString({
+      accountNumber: '670100-2214376555/6210',
+      amount: 100,
+      currency: 'CZK',
+      variableSymbol: '20260001'
+    })
+
+    expect(qrPaymentData).toBe(
+      'SPD*1.0*ACC:CZ4362106701002214376555*AM:100.00*CC:CZK*X-VS:20260001'
+    )
+  })
+})
+
+describe('normalizeAccountNumberForQrPayment', () => {
+  it('normalizes Czech domestic account variants to IBAN', () => {
+    expect(normalizeAccountNumberForQrPayment('19-2000145399/0800')).toBe(
+      'CZ6508000000192000145399'
+    )
+    expect(normalizeAccountNumberForQrPayment('2214376555/6210')).toBe(
+      'CZ7662100000002214376555'
+    )
+    expect(
+      normalizeAccountNumberForQrPayment(' CZ28 0600 0000 0000 0000 0123 ')
+    ).toBe('CZ2806000000000000000123')
   })
 })

--- a/faktorio-fe/src/lib/qrCodeGenerator.ts
+++ b/faktorio-fe/src/lib/qrCodeGenerator.ts
@@ -1,9 +1,49 @@
 export interface BankingInfo {
-  accountNumber: string | null // The bank account number in IBAN format
+  accountNumber: string | null // The bank account number in IBAN or Czech domestic format
   amount: number // The amount to be transferred
   currency: string // The currency code (e.g., CZK, EUR)
   message?: string // Optional payment message to the recipient
   variableSymbol?: string // Optional variable symbol for identifying the payment
+}
+
+const CZECH_DOMESTIC_ACCOUNT_REGEX = /^(?:(\d{1,6})-)?(\d{1,10})\/(\d{4})$/
+
+const calculateIbanCheckDigits = (bban: string): string => {
+  // ISO 13616 check digit calculation for Czech IBANs. CZ is represented as 1235.
+  const rearranged = `${bban}123500`
+  let remainder = 0
+
+  for (const character of rearranged) {
+    remainder = (remainder * 10 + Number(character)) % 97
+  }
+
+  return String(98 - remainder).padStart(2, '0')
+}
+
+export const normalizeAccountNumberForQrPayment = (
+  accountNumber: string | null
+): string | null => {
+  const normalizedAccountNumber = accountNumber?.replace(/\s/g, '') ?? null
+
+  if (!normalizedAccountNumber) {
+    return null
+  }
+
+  const czechDomesticAccountMatch = normalizedAccountNumber.match(
+    CZECH_DOMESTIC_ACCOUNT_REGEX
+  )
+
+  if (!czechDomesticAccountMatch) {
+    return normalizedAccountNumber
+  }
+
+  const [, prefix = '', account, bankCode] = czechDomesticAccountMatch
+  const bban = `${bankCode}${prefix.padStart(6, '0')}${account.padStart(
+    10,
+    '0'
+  )}`
+
+  return `CZ${calculateIbanCheckDigits(bban)}${bban}`
 }
 
 /** Generate a QR payment string from banking information. Should work for most czech banking mobile apps */
@@ -12,15 +52,17 @@ export function generateQrPaymentString(
 ): string | null {
   const { accountNumber, amount, currency, message, variableSymbol } =
     bankingInfo
+  const normalizedAccountNumber =
+    normalizeAccountNumberForQrPayment(accountNumber)
 
-  if (!accountNumber) {
+  if (!normalizedAccountNumber) {
     return null
   }
   // Start with the payment identifier and version
   let qrData = 'SPD*1.0'
 
   // Add the account number
-  qrData += `*ACC:${accountNumber}`
+  qrData += `*ACC:${normalizedAccountNumber}`
 
   // Add the amount formatted to two decimal places
   qrData += `*AM:${amount.toFixed(2)}`


### PR DESCRIPTION
### Motivation
- Some Czech banking apps mis-interpret domestic account formats placed directly into SPD QR payloads, so domestic-format accounts (e.g. `670100-XXXXXXXX/6210`) must be converted to Czech IBANs before generating the `ACC` field.

### Description
- Add `normalizeAccountNumberForQrPayment` with a regex for Czech domestic formats and `calculateIbanCheckDigits` to convert BBAN to Czech IBAN in `faktorio-fe/src/lib/qrCodeGenerator.ts`.
- Update `generateQrPaymentString` to use the normalized account number for the `ACC` field and preserve existing IBAN inputs after trimming whitespace.
- Add unit tests covering the reported Fio case and other Czech domestic variants in `faktorio-fe/src/lib/qrCodeGenerator.spec.ts`.
- Minor formatting and spec adjustments to ensure consistent snapshots and imports.

### Testing
- Ran the focused unit tests with `pnpm --filter faktorio-fe test -- qrCodeGenerator.spec.ts`, and they passed (all tests green).
- Ran TypeScript typecheck with `pnpm --filter faktorio-fe tsc`, which completed successfully.
- Ran `pnpm exec prettier --write` on the changed files as part of the workflow and had no formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58249967d883329f2b43a62bb8d21a)